### PR TITLE
Fix warnings that are shown when running npm start

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 import "./App.css";
 import { data as suitData, Item, Data } from "./data";
 


### PR DESCRIPTION
### The issue

When running `npm start`:
<img width="704" alt="image" src="https://github.com/AniOrava/code-test-4-4-2024/assets/15730756/b4f15c15-7d2e-46a2-b519-722f0d25ca07">

This is due to unused code in `App.tsx`.
This is not a nice experience for a new user in this project.

### The solution
Add /* eslint-disable @typescript-eslint/no-unused-vars */ to the `App.tsx` file, as the unused code is intentional.
